### PR TITLE
Normalize browse-selected paths to system-native separators

### DIFF
--- a/wsbu.py
+++ b/wsbu.py
@@ -197,12 +197,12 @@ class WindhawkManagerApp:
     def select_windhawk_path(self):
         path = filedialog.askdirectory(title="Select Windhawk Installation Directory", initialdir=self.windhawk_path_var.get())
         if path:
-            self.windhawk_path_var.set(path)
+            self.windhawk_path_var.set(os.path.normpath(path))
 
     def select_backup_path(self):
         path = filedialog.askdirectory(title="Select Backup Destination Folder", initialdir=self.backup_path_var.get())
         if path:
-            self.backup_path_var.set(path)
+            self.backup_path_var.set(os.path.normpath(path))
             
     def log(self, message, level="info"):
         """Writes a message to the log widget with appropriate color coding."""


### PR DESCRIPTION
### Motivation
- Ensure paths selected via the GUI use the OS-native separator so displayed paths match the filesystem and avoid potential inconsistencies when users pick locations via `filedialog.askdirectory`.

### Description
- Use `os.path.normpath` when setting the Windhawk root and Backup destination after the user selects a directory in `select_windhawk_path` and `select_backup_path` to normalize separators and path formatting.
